### PR TITLE
Limit the number of Redis Get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
 - redis-server
 
 go:
-  - 1.8.x
   - 1.9.x
   - 1.10.x
   - 1.11.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 - redis-server
 
 go:
+  - 1.8.x
   - 1.9.x
   - 1.10.x
   - 1.11.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
   - go get github.com/onsi/gomega
   - go get github.com/go-redis/redis
   - go get github.com/vmihailenco/msgpack
-  - go get github.com/go-redis/cache
-  
+
 before_script:
   - redis-server --port 6380 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - go get github.com/onsi/gomega
   - go get github.com/go-redis/redis
   - go get github.com/vmihailenco/msgpack
-
+  - go get github.com/go-redis/cache
+  
 before_script:
   - redis-server --port 6380 &

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	go test ./
-	go test ./ -short -race
-	env GOOS=linux GOARCH=386 go test ./
+	go test ./...
+	go test ./... -short -race
+	env GOOS=linux GOARCH=386 go test ./...
 	go vet

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 all:
 	go test ./...
 	go test ./... -short -race
-	env GOOS=linux GOARCH=386 go test ./...
-	go vet
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	go test ./...
-	go test ./... -short -race
-	env GOOS=linux GOARCH=386 go test ./...
+	go test ./
+	go test ./ -short -race
+	env GOOS=linux GOARCH=386 go test ./
 	go vet

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,8 +1,8 @@
 package cache_test
 
 import (
-	"../cache"
 	"fmt"
+	"github.com/WhisperRain/cache"
 	"testing"
 	"time"
 )

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,11 +1,10 @@
 package cache_test
 
 import (
+	"../cache"
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/go-redis/cache"
 )
 
 func BenchmarkOnce(b *testing.B) {

--- a/cache.go
+++ b/cache.go
@@ -77,7 +77,7 @@ func NewCodec(ring *redis.Ring,
 
 	codec := &Codec{
 		Redis:     ring,
-		chans:     limitget.Chans{M: make(map[string]bool)},
+		chans:     limitget.Chans{MaxConCh: make(chan uint8, limitget.MaxConcurrency)},
 		Marshal:   marshal,
 		Unmarshal: unmarshal,
 	}
@@ -174,9 +174,9 @@ func (cd *Codec) getBytes(key string, onlyLocalCache bool) ([]byte, error) {
 		return nil, ErrCacheMiss
 	}
 
-	cd.chans.LimitGet(key)
+	cd.chans.LimitGet()
 	defer func() {
-		cd.chans.ReleaseGet(key)
+		cd.chans.ReleaseGet()
 	}()
 	//if data expires, we need refresh data . At that time, the time cost may be long enough
 	b, err := cd.Redis.Get(key).Bytes()

--- a/cache.go
+++ b/cache.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/go-redis/redis"
 
-	"github.com/go-redis/cache/internal/limitget"
-	"github.com/go-redis/cache/internal/lrucache"
-	"github.com/go-redis/cache/internal/singleflight"
+	"./internal/limitget"
+	"./internal/lrucache"
+	"./internal/singleflight"
 )
 
 var ErrCacheMiss = errors.New("cache: key is missing")

--- a/cache.go
+++ b/cache.go
@@ -55,7 +55,6 @@ func (item *Item) exp() time.Duration {
 	return item.Expiration
 }
 
-
 type Codec struct {
 	Redis rediser
 
@@ -73,7 +72,10 @@ type Codec struct {
 	localMisses uint64
 }
 
-func NewCodec(ring *redis.Ring, marshal func(interface{}) ([]byte, error), unmarshal func([]byte, interface{}) error) *Codec {
+func NewCodec(ring *redis.Ring,
+	marshal func(interface{}) ([]byte, error),
+	unmarshal func([]byte, interface{}) error) *Codec {
+
 	codec := &Codec{
 		Redis:     ring,
 		chans:     singleget.Chans{M: make(map[string]chan uint8)},

--- a/cache.go
+++ b/cache.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/go-redis/redis"
 
-	"./internal/limitget"
-	"./internal/lrucache"
-	"./internal/singleflight"
+	"github.com/WhisperRain/cache/internal/limitget"
+	"github.com/WhisperRain/cache/internal/lrucache"
+	"github.com/WhisperRain/cache/internal/singleflight"
 )
 
 var ErrCacheMiss = errors.New("cache: key is missing")

--- a/cache_test.go
+++ b/cache_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/vmihailenco/msgpack"
 
-	"../cache"
+	"github.com/WhisperRain/cache"
 )
 
 func TestGinkgo(t *testing.T) {

--- a/cache_test.go
+++ b/cache_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/vmihailenco/msgpack"
 
-	"github.com/go-redis/cache"
+	"../cache"
 )
 
 func TestGinkgo(t *testing.T) {
@@ -328,6 +328,5 @@ func newCodec() *cache.Codec {
 		}, func(b []byte, v interface{}) error {
 			return msgpack.Unmarshal(b, v)
 		})
-
 
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -322,14 +322,12 @@ func newCodec() *cache.Codec {
 		return client.FlushDb().Err()
 	})
 
-	return &cache.Codec{
-		Redis: ring,
-
-		Marshal: func(v interface{}) ([]byte, error) {
+	return cache.NewCodec(ring,
+		func(v interface{}) ([]byte, error) {
 			return msgpack.Marshal(v)
-		},
-		Unmarshal: func(b []byte, v interface{}) error {
+		}, func(b []byte, v interface{}) error {
 			return msgpack.Unmarshal(b, v)
-		},
-	}
+		})
+
+
 }

--- a/example_cache_test.go
+++ b/example_cache_test.go
@@ -23,16 +23,13 @@ func Example_basicUsage() {
 		},
 	})
 
-	codec := &cache.Codec{
-		Redis: ring,
-
-		Marshal: func(v interface{}) ([]byte, error) {
+	codec := cache.NewCodec(ring,
+		func(v interface{}) ([]byte, error) {
 			return msgpack.Marshal(v)
 		},
-		Unmarshal: func(b []byte, v interface{}) error {
+		func(b []byte, v interface{}) error {
 			return msgpack.Unmarshal(b, v)
-		},
-	}
+		})
 
 	key := "mykey"
 	obj := &Object{
@@ -62,16 +59,13 @@ func Example_advancedUsage() {
 		},
 	})
 
-	codec := &cache.Codec{
-		Redis: ring,
-
-		Marshal: func(v interface{}) ([]byte, error) {
+	codec := cache.NewCodec(ring,
+		func(v interface{}) ([]byte, error) {
 			return msgpack.Marshal(v)
 		},
-		Unmarshal: func(b []byte, v interface{}) error {
+		func(b []byte, v interface{}) error {
 			return msgpack.Unmarshal(b, v)
-		},
-	}
+		})
 
 	obj := new(Object)
 	err := codec.Once(&cache.Item{

--- a/example_cache_test.go
+++ b/example_cache_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-redis/redis"
 	"github.com/vmihailenco/msgpack"
 
-	"../cache"
+	"github.com/WhisperRain/cache"
 )
 
 type Object struct {

--- a/example_cache_test.go
+++ b/example_cache_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-redis/redis"
 	"github.com/vmihailenco/msgpack"
 
-	"github.com/go-redis/cache"
+	"../cache"
 )
 
 type Object struct {

--- a/internal/limitget/limitget.go
+++ b/internal/limitget/limitget.go
@@ -1,6 +1,6 @@
 package limitget
 
-// The module is designed for getting data from database.
+// The module is designed for limiting concurrency of getting data from database.
 // limitget is designed limit the number of Get
 
 import "sync"

--- a/internal/limitget/limitget.go
+++ b/internal/limitget/limitget.go
@@ -46,10 +46,12 @@ func (chs *Chans) SetChan(key string) {
 func (chs *Chans) DeleteChan(key string) {
 	chs.Lock()
 	defer chs.Unlock()
-	ch, _ := chs.GetChan(key)
+	ch, ok := chs.GetChan(key)
+	if !ok {
+		return
+	}
 
 	delete(chs.M, key)
-	<-chs.maxConCh
-
 	close(ch) //Notify channel to stop waiting
+	<-chs.maxConCh
 }

--- a/internal/limitget/limitget.go
+++ b/internal/limitget/limitget.go
@@ -7,13 +7,13 @@ package limitget
 var MaxConcurrency = 1000
 
 type Chans struct {
-	maxConCh chan uint8 //The channel is used for control the max concurrency number of get data from database
+	MaxConCh chan uint8 //The channel is used for control the max concurrency number of get data from database
 }
 
 func (chs *Chans) LimitGet() {
-	chs.maxConCh <- uint8(1)
+	chs.MaxConCh <- uint8(1)
 }
 
 func (chs *Chans) ReleaseGet() {
-	<-chs.maxConCh
+	<-chs.MaxConCh
 }

--- a/internal/limitget/limitget.go
+++ b/internal/limitget/limitget.go
@@ -46,7 +46,7 @@ func (chs *Chans) SetChan(key string) {
 func (chs *Chans) DeleteChan(key string) {
 	chs.Lock()
 	defer chs.Unlock()
-	ch, ok := chs.GetChan(key)
+	ch, ok := chs.M[key]
 	if !ok {
 		return
 	}

--- a/internal/limitget/limitget.go
+++ b/internal/limitget/limitget.go
@@ -1,16 +1,17 @@
 package limitget
 
-// limitget is designed limit the number of Redis.Get.
+// The module is designed for getting data from database.
+// limitget is designed limit the number of Get
 
 import "sync"
 
-// MaxConcurrency represents the total number of Redis.Get with all kinds of key.
+// MaxConcurrency represents the total number of Get with all kinds of key.
 var MaxConcurrency = 1000
 
 type Chans struct {
 	sync.Mutex // protects m
 	M          map[string]bool
-	maxConCh   chan uint8 //The channel is used for control the max concurrency number of Redis.Get
+	maxConCh   chan uint8 //The channel is used for control the max concurrency number of get data from database
 }
 
 func (chs *Chans) LimitGet(key string) {

--- a/internal/limitget/limitget.go
+++ b/internal/limitget/limitget.go
@@ -3,49 +3,17 @@ package limitget
 // The module is designed for limiting concurrency of getting data from database.
 // limitget is designed limit the number of Get
 
-import "sync"
-
 // MaxConcurrency represents the total number of Get with all kinds of key.
 var MaxConcurrency = 1000
 
 type Chans struct {
-	sync.Mutex // protects m
-	M          map[string]bool
-	maxConCh   chan uint8 //The channel is used for control the max concurrency number of get data from database
+	maxConCh chan uint8 //The channel is used for control the max concurrency number of get data from database
 }
 
 func (chs *Chans) LimitGet(key string) {
-	chs.Lock()
-	_, ok := chs.M[key]
-	chs.Unlock()
-
-	if !ok {
-		chs.set(key)
-	}
-}
-
-func (chs *Chans) set(key string) {
-	chs.Lock()
-	if chs.maxConCh == nil {
-		chs.maxConCh = make(chan uint8, MaxConcurrency)
-	}
-	chs.Unlock()
-
 	chs.maxConCh <- uint8(1)
-
-	chs.Lock()
-	chs.M[key] = true
-	chs.Unlock()
 }
 
 func (chs *Chans) ReleaseGet(key string) {
-	chs.Lock()
-	defer chs.Unlock()
-	_, ok := chs.M[key]
-	if !ok {
-		return
-	}
-
-	delete(chs.M, key)
 	<-chs.maxConCh
 }

--- a/internal/limitget/limitget.go
+++ b/internal/limitget/limitget.go
@@ -1,9 +1,10 @@
-package singleget
+package limitget
 
 import "sync"
 
-// Chans is designed save map[key]channel.
-// It makes sure that only two getBytes goroutine is in-flight for a given key at a
+// limitget is designed limit the number of Redis.Get with same key at a time.
+// The number could be any value above 0. But it's const number.It shouldn't be too big.
+// It makes sure that only MaxGetNum Redis.Get is in-flight for a given key at a
 // time. If a new one comes in, the duplicate caller waits for the
 // old one to complete and receives the same results.
 // Of course MaxGetNum can be modified easily in cache.go

--- a/internal/limitget/limitget.go
+++ b/internal/limitget/limitget.go
@@ -1,12 +1,11 @@
 package limitget
+
 // limitget is designed limit the number of Redis.Get.
 
 import "sync"
 
 // MaxConcurrency represents the total number of Redis.Get with all kinds of key.
 var MaxConcurrency = 1000
-//MaxGetNum represents the number of Redis.Get with same key at a time.
-var MaxGetNum = uint8(2)
 
 type Chans struct {
 	sync.Mutex // protects m
@@ -32,11 +31,7 @@ func (chs *Chans) SetChan(key string) {
 	chs.maxConCh <- uint8(1)
 
 	// We new a channel which represents the status of getting or not.
-	ch := make(chan uint8, MaxGetNum-1)  // MaxGetNum-1>=0
-	//MaxGetNum goroutine doesn't need to wait.
-	for i := uint8(0); i < MaxGetNum-1; i++ {
-		ch <- uint8(1)
-	}
+	ch := make(chan uint8)
 
 	chs.Lock()
 	chs.M[key] = ch

--- a/internal/limitget/limitget.go
+++ b/internal/limitget/limitget.go
@@ -10,10 +10,10 @@ type Chans struct {
 	maxConCh chan uint8 //The channel is used for control the max concurrency number of get data from database
 }
 
-func (chs *Chans) LimitGet(key string) {
+func (chs *Chans) LimitGet() {
 	chs.maxConCh <- uint8(1)
 }
 
-func (chs *Chans) ReleaseGet(key string) {
+func (chs *Chans) ReleaseGet() {
 	<-chs.maxConCh
 }

--- a/internal/singleget/singleget.go
+++ b/internal/singleget/singleget.go
@@ -1,0 +1,31 @@
+package singleget
+
+import "sync"
+
+var refreshMutex sync.Mutex
+var refresh map[string]chan uint8
+
+func init() {
+	refreshMutex = sync.Mutex{}
+	refresh = make(map[string]chan uint8)
+}
+
+func GetChan(key string) (chan uint8, bool) {
+	refreshMutex.Lock()
+	defer refreshMutex.Unlock()
+	ch, refreshing := refresh[key]
+
+	return ch, refreshing
+}
+
+func SetChan(key string, ch chan uint8) {
+	refreshMutex.Lock()
+	defer refreshMutex.Unlock()
+	refresh[key] = ch
+}
+
+func DeleteChan(key string) {
+	refreshMutex.Lock()
+	defer refreshMutex.Unlock()
+	delete(refresh, key)
+}

--- a/internal/singleget/singleget.go
+++ b/internal/singleget/singleget.go
@@ -2,11 +2,13 @@ package singleget
 
 import "sync"
 
-// Group represents a class of work and forms a namespace in which
-// units of work can be executed with duplicate suppression.
+// Chans is designed save map[key]channel.
+// It makes sure that only one getBytes is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
 type Chans struct {
 	sync.Mutex       // protects m
-	M  map[string]chan uint8 // lazily initialized
+	M  map[string]chan uint8
 }
 
 func (chs *Chans)GetChan(key string) (chan uint8, bool) {

--- a/internal/singleget/singleget.go
+++ b/internal/singleget/singleget.go
@@ -2,30 +2,29 @@ package singleget
 
 import "sync"
 
-var refreshMutex sync.Mutex
-var refresh map[string]chan uint8
-
-func init() {
-	refreshMutex = sync.Mutex{}
-	refresh = make(map[string]chan uint8)
+// Group represents a class of work and forms a namespace in which
+// units of work can be executed with duplicate suppression.
+type Chans struct {
+	sync.Mutex       // protects m
+	M  map[string]chan uint8 // lazily initialized
 }
 
-func GetChan(key string) (chan uint8, bool) {
-	refreshMutex.Lock()
-	defer refreshMutex.Unlock()
-	ch, refreshing := refresh[key]
+func (chs *Chans)GetChan(key string) (chan uint8, bool) {
+	chs.Lock()
+	defer chs.Unlock()
+	ch, refreshing := chs.M[key]
 
 	return ch, refreshing
 }
 
-func SetChan(key string, ch chan uint8) {
-	refreshMutex.Lock()
-	defer refreshMutex.Unlock()
-	refresh[key] = ch
+func  (chs *Chans)SetChan(key string, ch chan uint8) {
+	chs.Lock()
+	defer chs.Unlock()
+	chs.M[key] = ch
 }
 
-func DeleteChan(key string) {
-	refreshMutex.Lock()
-	defer refreshMutex.Unlock()
-	delete(refresh, key)
+func  (chs *Chans)DeleteChan(key string) {
+	chs.Lock()
+	defer chs.Unlock()
+	delete(chs.M, key)
 }

--- a/internal/singleget/singleget.go
+++ b/internal/singleget/singleget.go
@@ -3,9 +3,10 @@ package singleget
 import "sync"
 
 // Chans is designed save map[key]channel.
-// It makes sure that only one getBytes is in-flight for a given key at a
-// time. If a duplicate comes in, the duplicate caller waits for the
-// original to complete and receives the same results.
+// It makes sure that only two getBytes goroutine is in-flight for a given key at a
+// time. If a new one comes in, the duplicate caller waits for the
+// old one to complete and receives the same results.
+// Of course MaxGetNum can be modified easily in cache.go
 type Chans struct {
 	sync.Mutex       // protects m
 	M  map[string]chan uint8


### PR DESCRIPTION
The pr is designed to limit the number of getting or refreshing data from database.

Usually hot data in cache may be accessed with high frequency.