### PR TITLE
Demonstrate TinyLRU cache corruption on expiry

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -3,7 +3,9 @@ package cache_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +14,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/go-redis/cache/v8"
 )
@@ -398,6 +401,86 @@ var _ = Describe("Cache", func() {
 		testCache()
 	})
 })
+
+func TestCache_Get_CorruptionOnExpiry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this is a slow test")
+	}
+
+	strFor := func(i int) string {
+		return fmt.Sprintf("a string %d", i)
+	}
+	keyName := func(i int) string {
+		return fmt.Sprintf("key-%00000d", i)
+	}
+
+	// The local cache is configured with a cache of 1 minute
+	mycache := newCacheWithLocal(newRing())
+	size := 50000
+	// Put a bunch of stuff in the cache with a TTL of 1 minute
+	for i := 0; i < size; i++ {
+		key := keyName(i)
+
+		err := mycache.Set(&cache.Item{
+			Ctx: context.Background(),
+			Key: key,
+			Value: &Object{
+				Str: strFor(i),
+				Num: i,
+			},
+			TTL: time.Minute,
+		})
+		if err != nil {
+			t.Errorf("failed to set cache key: %s", key)
+		}
+	}
+
+	// Read stuff for a bit longer than the TTL - that's when the corruption occurs
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute+10*time.Second)
+	defer cancel()
+
+	g, ctx := errgroup.WithContext(ctx)
+	// Start lots of readers
+	for i := 0; i < 500; i++ {
+		g.Go(func() error {
+			done := ctx.Done()
+		loop:
+			for {
+				select {
+				case <-done:
+					return nil
+				default:
+					i := rand.Intn(size / 2) // only access half of the keys
+					key := keyName(i)
+
+					var obj Object
+					err := mycache.Get(ctx, key, &obj)
+					switch {
+					case errors.Is(err, cache.ErrCacheMiss):
+						continue loop
+					case err != nil:
+						return err
+					default:
+						if obj.Num != i {
+							return fmt.Errorf("expected obj.Num=%d to be=%d key=%q", obj.Num, i, key)
+						}
+						if obj.Str != strFor(i) {
+							return fmt.Errorf("obj.Str had wrong value %q", obj.Str)
+						}
+					}
+				}
+			}
+		})
+	}
+
+	err := g.Wait()
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		// this is expected
+	case err != nil:
+		t.Errorf("failed with error: %s", err)
+	}
+}
 
 func newRing() *redis.Ring {
 	ctx := context.TODO()

--- a/local_test.go
+++ b/local_test.go
@@ -1,0 +1,56 @@
+package cache_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/go-redis/cache/v8"
+)
+
+func TestTinyLFU_Get_CorruptionOnExpiry(t *testing.T) {
+	strFor := func(i int) string {
+		return fmt.Sprintf("a string %d", i)
+	}
+	keyName := func(i int) string {
+		return fmt.Sprintf("key-%00000d", i)
+	}
+
+	mycache := cache.NewTinyLFU(1000, 1*time.Second)
+	size := 50000
+	// Put a bunch of stuff in the cache with a TTL of 1 second
+	for i := 0; i < size; i++ {
+		key := keyName(i)
+		mycache.Set(key, []byte(strFor(i)))
+	}
+
+	// Read stuff for a bit longer than the TTL - that's when the corruption occurs
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := ctx.Done()
+loop:
+	for {
+		select {
+		case <-done:
+			// this is expected
+			break loop
+		default:
+			i := rand.Intn(size)
+			key := keyName(i)
+
+			b, ok := mycache.Get(key)
+			if !ok {
+				continue loop
+			}
+
+			got := string(b)
+			expected := strFor(i)
+			if got != expected {
+				t.Fatalf("expected=%q got=%q key=%q", expected, got, key)
+			}
+		}
+	}
+}


### PR DESCRIPTION
In using this library we discovered when using the recommended TinyLRU local cache, that we were seeing corruption when the items in the cache started expiring.

I.e. that the cache returned values for the wrong key when retrieving them.

This test reproduces the issue every time on my MacBook running Go 1.17 (`go version go1.17 darwin/amd64`).

(Apologies for the test being slow and not using Gingko, I don't really expect this PR to be merged as-is.)