### PR TITLE
Add cache hit field in Item

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -59,6 +59,9 @@ type Item struct {
 
 	// SkipLocalCache skips local cache as if it is not set.
 	SkipLocalCache bool
+
+	// CacheHit is true if Value is found in the cache.
+	CacheHit bool
 }
 
 func (item *Item) Context() context.Context {
@@ -259,6 +262,7 @@ func (cd *Cache) Once(item *Item) error {
 	if err != nil {
 		return err
 	}
+	item.CacheHit = cached
 
 	if item.Value == nil || len(b) == 0 {
 		return nil

--- a/cache_test.go
+++ b/cache_test.go
@@ -227,6 +227,30 @@ var _ = Describe("Cache", func() {
 				Expect(callCount).To(Equal(int64(1)))
 			})
 
+			It("works with CacheHit", func() {
+				key := "cache-hit-test"
+				do := func(item *cache.Item) (interface{}, error) {
+					return "hello", nil
+				}
+				var value string
+				item := cache.Item{
+					Ctx:   ctx,
+					Key:   key,
+					Value: &value,
+					Do:    do,
+				}
+
+				err := mycache.Once(&item)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(item.CacheHit).To(Equal(false))
+
+				err = mycache.Once(&item)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(item.CacheHit).To(Equal(true))
+			})
+
 			It("works with ptr and non-ptr", func() {
 				var callCount int64
 				perform(100, func(int) {


### PR DESCRIPTION
Add cache hit field in Item.

Hello :) I want to record cache metrics with labels when calling `Once` function like below

```go
	item := &Item{}
	if err := cache.Once(item); err != nil {
		return err
	}

	metrics.IncCacheTotal("product")
	if item.CacheHit {
		metrics.IncCacheHit("product")
	}
```

I found `Stats()` function but this function provides only total count of hits and misses :(
