### PR TITLE
Return error explicitly when TTL = - 1

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -27,6 +27,7 @@ const (
 var (
 	ErrCacheMiss          = errors.New("cache: key is missing")
 	errRedisLocalCacheNil = errors.New("cache: both Redis and LocalCache are nil")
+	ErrInvalidTTL         = errors.New("cache: invalid ttl value")
 )
 
 type rediser interface {
@@ -171,7 +172,7 @@ func (cd *Cache) set(item *Item) ([]byte, bool, error) {
 
 	ttl := item.ttl()
 	if ttl == 0 {
-		return b, true, nil
+		return b, false, ErrInvalidTTL
 	}
 
 	if item.SetXX {

--- a/cache_test.go
+++ b/cache_test.go
@@ -337,7 +337,7 @@ var _ = Describe("Cache", func() {
 				Expect(callCount).To(Equal(int64(2)))
 			})
 
-			It("skips Set when TTL = -1", func() {
+			It("skips Set when TTL = -1 and return error", func() {
 				key := "skip-set"
 
 				var value string
@@ -347,10 +347,11 @@ var _ = Describe("Cache", func() {
 					Value: &value,
 					Do: func(item *cache.Item) (interface{}, error) {
 						item.TTL = -1
-						return "hello", nil
+						return "hello", cache.ErrInvalidTTL
 					},
 				})
-				Expect(err).NotTo(HaveOccurred())
+
+				Expect(err).To(Equal(cache.ErrCacheMiss))
 				Expect(value).To(Equal("hello"))
 
 				if rdb != nil {


### PR DESCRIPTION
Hello! 👋🏻 

I've tried to use go-cache library for some permanently caching use cases and a little bit confused with `Set` function behaviour using ttl < 0 and found similar [issue](https://github.com/go-redis/cache/issues/65).

I suggest to return error value explicitly to avoid undefined behaviour on client applications.


I would appreciate for your reply.
Best regard, Roman.