### PR TITLE
Only check for byte existence for Exists

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -185,7 +185,8 @@ func (cd *Cache) set(item *Item) ([]byte, bool, error) {
 
 // Exists reports whether value for the given key exists.
 func (cd *Cache) Exists(ctx context.Context, key string) bool {
-	return cd.Get(ctx, key, nil) == nil
+	_, err := cd.getBytes(ctx, key, false)
+	return err == nil
 }
 
 // Get gets the value for the given key.


### PR DESCRIPTION
Using Get() under the hood requires users who want to set their own Unmarshal function to know to always return nil when they are passed a nil value. This change allows Exists to work regardless of the Unmarshal implementation.