### PR TITLE
keep method UseRandomizedTTL thread safe

### DIFF
--- a/local.go
+++ b/local.go
@@ -41,6 +41,9 @@ func NewTinyLFU(size int, ttl time.Duration) *TinyLFU {
 }
 
 func (c *TinyLFU) UseRandomizedTTL(offset time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.offset = offset
 }
 


### PR DESCRIPTION
Hello

this method is not thread safe. I am not sure what was the intent with such method BTW

also, the LFU cache is already thread safe, it is not need add a mutex on the wrapper.

if it is possible remove this method at some point, there is no need for mutex