### PR TITLE
feat: support-keepttl

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -82,7 +82,7 @@ func (item *Item) ttl() time.Duration {
 	const defaultTTL = time.Hour
 
 	if item.TTL < 0 {
-		return 0
+		return redis.KeepTTL
 	}
 
 	if item.TTL != 0 {

--- a/cache_test.go
+++ b/cache_test.go
@@ -337,26 +337,29 @@ var _ = Describe("Cache", func() {
 				Expect(callCount).To(Equal(int64(2)))
 			})
 
-			It("skips Set when TTL = -1", func() {
-				key := "skip-set"
+			It("Set when TTL = -1", func() {
+				key := "set-with-keepttl"
 
 				var value string
+				var callCount int64
 				err := mycache.Once(&cache.Item{
 					Ctx:   ctx,
 					Key:   key,
 					Value: &value,
 					Do: func(item *cache.Item) (interface{}, error) {
+						atomic.AddInt64(&callCount, 1)
 						item.TTL = -1
 						return "hello", nil
 					},
 				})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(value).To(Equal("hello"))
+				Expect(callCount).To(Equal(int64(1)))
 
 				if rdb != nil {
-					exists, err := rdb.Exists(ctx, key).Result()
+					ttl, err := rdb.TTL(ctx, key).Result()
 					Expect(err).NotTo(HaveOccurred())
-					Expect(exists).To(Equal(int64(0)))
+					Expect(ttl).To(Equal(time.Duration(redis.KeepTTL)))
 				}
 			})
 		})


### PR DESCRIPTION
When we try to pass `-1` into TTL, we are always disappointed to find that it does not work as expected.

When we saw the source code `if item.TTL < 0 { return 0 }`, we were a little surprised.

I do understand that for a cache, non-expiring keys are risky.

However, I believe that everyone knows what they are doing when setting TTL to `-1`, which is consistent with the Redis parameters.


How to use:

```go
// from readme demo code
err := mycache.Once(&cache.Item{
		Key:   "mykey",
		Value: obj,
		TTL:   redis.KeepTTL, // Changed here
		Do: func(*cache.Item) (interface{}, error) {
			return &Object{
				Str: "mystring",
				Num: 42,
			}, nil
		},
	})
```